### PR TITLE
Add folder for init scripts, associated README and systemd service

### DIFF
--- a/init/README.md
+++ b/init/README.md
@@ -1,0 +1,13 @@
+# Nighfall Init Services
+
+This folder contains service files that can be used for nightfall
+
+## Systemd
+
+The **systemd** service file is `nightfall.service`
+
+### Notes
+
+* To install the service, copy the service file to: `/etc/systemd/system` and run: `systemctl daemon-reload`
+* The service is run by the **nightfall** user, which can be added by running: `useradd -d / -s /usr/bin/nologin nightfall`
+* The service expects the **nightfall.js** script to be installed to: `/usr/bin/nightfall`

--- a/init/nightfall.service
+++ b/init/nightfall.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Cjdns inet auto-peering tracker
+After=network.target
+
+[Service]
+User=nightfall
+Group=nightfall
+ExecStart=/usr/bin/nightfall
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This adds an **init script folder**, a **systemd service**, and a **README** with details about the systemd service, organized with the expectation that additional services will be added in the future