### PR TITLE
validate field types on peer announcement

### DIFF
--- a/nightfall.js
+++ b/nightfall.js
@@ -111,7 +111,7 @@ var main = nightfall.main = function(req, res, next) {
         reply = {'error': 'not json'};
       }
 
-      if(json && !('ip' in json || 'ts' in json)) {
+      if(json && !('ip' in json || 'ts' in json) && typeof json.port === 'number' && typeof json.password === 'string' && typeof json.publicKey === 'string') {
         if(!(topic in bucket)) {
           console.log('creating bucket[%s]', topic);
           bucket[topic] = {};


### PR DESCRIPTION
I noticed that there is a peer sending the port as a string, which causes yrd to fail. Therefor I added some basic type validation. Maybe this should go into its own function at some point. For now I extended the if statement checking whether the JSON is correct.